### PR TITLE
feat: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# plugin-authentication
+# api-plugin-authentication
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-authentication.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-authentication)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-authentication.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-authentication)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-authentication.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-authentication)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-authentication.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-authentication)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-authentication",
+  "name": "@reactioncommerce/api-plugin-authentication",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-authentication",
+  "name": "@reactioncommerce/api-plugin-authentication",
   "description": "Authentication plugin for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
@@ -7,12 +7,12 @@
   "engines": {
     "node": ">=12.14.1"
   },
-  "homepage": "https://github.com/reactioncommerce/plugin-authentication",
-  "url": "https://github.com/reactioncommerce/plugin-authentication",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-authentication",
+  "url": "https://github.com/reactioncommerce/api-plugin-authentication",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-authentication.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-authentication.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-authentication/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-authentication/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import tokenMiddleware from "./util/tokenMiddleware.js";
 export default async function register(app) {
   await app.registerPlugin({
     label: "Authentication",
-    name: "reaction-authentication",
+    name: "authentication",
     version: pkg.version,
     collections: {
       users: {


### PR DESCRIPTION
Resolves #3

Rename this plugin from `plugin-authentication` to `api-plugin-authentication`.

This will create a new npm package with a v1.1.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.