### PR TITLE
feat: Enable mock TLS termination on calls to Hydra

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,8 @@ import envalid from "envalid";
 const { str } = envalid;
 
 export default envalid.cleanEnv(process.env, {
-  HYDRA_OAUTH2_INTROSPECT_URL: str({ devDefault: "http://hydra:4445/oauth2/introspect" })
+  HYDRA_OAUTH2_INTROSPECT_URL: str({ devDefault: "http://hydra:4445/oauth2/introspect" }),
+  MOCK_TLS_TERMINATION: envalid.bool({ default: false }),
 }, {
   dotEnvPath: null
 });

--- a/src/util/expandAuthToken.js
+++ b/src/util/expandAuthToken.js
@@ -1,7 +1,14 @@
 import fetch from "node-fetch";
 import config from "../config.js";
 
-const { HYDRA_OAUTH2_INTROSPECT_URL } = config;
+const { HYDRA_OAUTH2_INTROSPECT_URL, MOCK_TLS_TERMINATION } = config;
+
+let mockTlsTermination = {};
+if (MOCK_TLS_TERMINATION) {
+  mockTlsTermination = {
+    "X-Forwarded-Proto": "https"
+  };
+}
 
 /**
  * Given an Authorization Bearer token it returns a JSON object with user
@@ -15,7 +22,7 @@ const { HYDRA_OAUTH2_INTROSPECT_URL } = config;
  */
 export default async function expandAuthToken(token) {
   const response = await fetch(HYDRA_OAUTH2_INTROSPECT_URL, {
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: { "Content-Type": "application/x-www-form-urlencoded", ...mockTlsTermination },
     method: "POST",
     body: `token=${encodeURIComponent(token)}`
   });


### PR DESCRIPTION
This is the same change as in https://github.com/reactioncommerce/reaction-identity/pull/35

Uses the same environment variable `MOCK_TLS_TERMINATION` to enable a header in Hydra calls.

As described in the original PR, *all* calls to Hydra (even admin ones) require the header otherwise it will reject it.