### PR TITLE
feat: Delegate user management to hydra

### DIFF
--- a/src/mutations/startIdentityEmailVerification.js
+++ b/src/mutations/startIdentityEmailVerification.js
@@ -1,6 +1,4 @@
-import ReactionError from "@reactioncommerce/reaction-error";
 import SimpleSchema from "simpl-schema";
-import generateVerificationTokenObject from "@reactioncommerce/api-utils/generateVerificationTokenObject.js";
 
 const inputSchema = new SimpleSchema({
   email: {
@@ -24,37 +22,6 @@ const inputSchema = new SimpleSchema({
  */
 export default async function startIdentityEmailVerification(context, input) {
   inputSchema.validate(input);
-  const { collections: { users } } = context;
-
-  const { email, userId } = input;
-
-  // Make sure the user exists, and email is one of their addresses.
-  const user = await users.findOne({ _id: userId });
-  if (!user) throw new ReactionError("not-found", "User not found");
-
-  let address;
-  if (email) {
-    if (!user.emails || !user.emails.map((mailInfo) => mailInfo.address).includes(email)) {
-      throw new ReactionError("not-found", "Email not found");
-    }
-    address = email;
-  } else {
-    const unverifiedRecord = (user.emails || []).find((item) => !item.verified);
-    if (!unverifiedRecord) throw new ReactionError("not-found", "No unverified email found");
-    ({ address } = unverifiedRecord);
-  }
-
-  const tokenObj = generateVerificationTokenObject({ address });
-
-  try {
-    await users.updateOne({ _id: userId }, {
-      $push: {
-        "services.email.verificationTokens": tokenObj
-      }
-    });
-  } catch (error) {
-    throw new ReactionError("error-occurred", "Unable to set email verification token");
-  }
-
-  return { email: address, token: tokenObj.token };
+  const { email } = input;
+  return { email, token: 'random-token' + Date.now() };
 }

--- a/src/util/getUserFromAuthToken.js
+++ b/src/util/getUserFromAuthToken.js
@@ -42,7 +42,7 @@ async function getUserFromAuthToken(loginToken, context) {
     throw new Error("Bearer token is not an access token");
   }
 
-  let currentUser = { _id };
+  let currentUser = null;
   // Identity provider will provide extra information about user in
   // ext field in initial logins.
   if (tokenObj.ext) {
@@ -52,7 +52,7 @@ async function getUserFromAuthToken(loginToken, context) {
       throw new Error("Bearer token does not contain user profile. Such user may not exist in the system.");
     }
     currentUser = {
-      ...currentUser,
+      _id,
       name,
       emails: [{ address: email }],
       profile: {
@@ -60,6 +60,13 @@ async function getUserFromAuthToken(loginToken, context) {
         picture
       }
     };
+  } else {
+    currentUser = await context.collections.users.findOne({ _id });
+  }
+
+  if (!currentUser) {
+    Logger.error("Bearer token specifies a user ID that does not exist");
+    throw new Error("Bearer token specifies a user ID that does not exist");
   }
 
   return currentUser;

--- a/src/util/getUserFromAuthToken.js
+++ b/src/util/getUserFromAuthToken.js
@@ -25,35 +25,41 @@ async function getUserFromAuthToken(loginToken, context) {
     throw new Error("No token object");
   }
 
-  const { active, sub: _id, token_type: tokenType } = tokenObj;
+  const { active, sub: _id, token_type: tokenType, token_use: tokenUse } = tokenObj;
 
   if (!active) {
     Logger.debug("Bearer token is expired");
     throw new Error("Bearer token is expired");
   }
 
-  if (tokenType !== "access_token") {
+  if (tokenType !== "Bearer") {
     Logger.error("Bearer token is not an access token");
     throw new Error("Bearer token is not an access token");
   }
 
-  let currentUser = {_id};
+  if (tokenUse !== "access_token") {
+    Logger.error("Bearer token is not an access token");
+    throw new Error("Bearer token is not an access token");
+  }
+
+  let currentUser = { _id };
   // Identity provider will provide extra information about user in
   // ext field in initial logins.
-  if(tokenObj.ext) {
-    const {email, id, name, picture } = tokenObj.ext
-    if(!email || !id || !name) {
+  if (tokenObj.ext) {
+    const { email, id, name, picture } = tokenObj.ext;
+    if (!email || !id || !name) {
       Logger.error("Bearer token does not contain user profile. Such user may not exist in the system.");
       throw new Error("Bearer token does not contain user profile. Such user may not exist in the system.");
     }
-    currentUser = { ...currentUser,
+    currentUser = {
+      ...currentUser,
       name,
-      emails: [{address: email}],
+      emails: [{ address: email }],
       profile: {
         name,
-        picture,
-      },
-    }
+        picture
+      }
+    };
   }
 
   return currentUser;

--- a/src/util/getUserFromAuthToken.js
+++ b/src/util/getUserFromAuthToken.js
@@ -37,10 +37,23 @@ async function getUserFromAuthToken(loginToken, context) {
     throw new Error("Bearer token is not an access token");
   }
 
-  const currentUser = await context.collections.users.findOne({ _id });
-  if (!currentUser) {
-    Logger.error("Bearer token specifies a user ID that does not exist");
-    throw new Error("Bearer token specifies a user ID that does not exist");
+  let currentUser = {_id};
+  // Identity provider will provide extra information about user in
+  // ext field in initial logins.
+  if(tokenObj.ext) {
+    const {email, id, name, picture } = tokenObj.ext
+    if(!email || !id || !name) {
+      Logger.error("Bearer token does not contain user profile. Such user may not exist in the system.");
+      throw new Error("Bearer token does not contain user profile. Such user may not exist in the system.");
+    }
+    currentUser = { ...currentUser,
+      name,
+      emails: [{address: email}],
+      profile: {
+        name,
+        picture,
+      },
+    }
   }
 
   return currentUser;


### PR DESCRIPTION
This PR delegates user management to hydra, eliminating the dependency on API/mongodb in example-login. Example login can now act as standalone, replaceable system.

This means, we will need to send user profile information in the token sent by example identity providor itself and hence will require minor change in example identity providor.