### PR TITLE
Fix: Unhandled promise rejection when sending reset account password email

### DIFF
--- a/src/util/accountServer.js
+++ b/src/util/accountServer.js
@@ -34,11 +34,11 @@ export default async (app) => {
       db: accountsMongo,
       enableAutologin: true,
       ambiguousErrorMessages: false,
-      sendMail: ({ to, text }) => {
+      sendMail: async ({ to, text }) => {
         const query = text.split("/");
         const token = query[query.length - 1];
         const url = `${STORE_URL}/?resetToken=${token}`;
-        context.mutations.sendResetAccountPasswordEmail(context, {
+        await context.mutations.sendResetAccountPasswordEmail(context, {
           email: to,
           url
         });


### PR DESCRIPTION
Signed-off-by: Chloe <pinkcloudvnn@gmail.com>

## Issue
`sendResetAccountPasswordEmail` throws an error when shop email is not found, however, it's not handled properly and the error got swallowed and the API still returns a success response.

<img width="1584" alt="Screen Shot 2022-06-20 at 15 49 57" src="https://user-images.githubusercontent.com/33818318/174565111-c45b00ff-0e51-4882-a69d-60065d0cd0f9.png">
<img width="530" alt="Screen Shot 2022-06-20 at 15 57 54" src="https://user-images.githubusercontent.com/33818318/174565119-17e1d73d-64f4-45fa-847e-c52710941574.png">

## Solution
Add async/await to wait for the result of the `sendResetAccountPasswordEmail` mutation and react to rejection, hence getting caught in the API handler.

<img width="801" alt="Screen Shot 2022-06-20 at 14 48 35" src="https://user-images.githubusercontent.com/33818318/174566180-9e01066f-1c67-4fc0-b99c-ef28d1a5f671.png">

